### PR TITLE
Refactoring folder structure of execution-manger to template-manager

### DIFF
--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -772,7 +772,7 @@
             <source>
                 src/repository/conf/domain-template/temperature-analysis.xml
             </source>
-            <outputDirectory>${pom.artifactId}-${pom.version}/repository/conf/execution-manager/domain-template</outputDirectory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/conf/template-manager/domain-template</outputDirectory>
             <filtered>true</filtered>
         </file>
 

--- a/modules/integration/tests-integration/src/test/java/org/wso2/das/integration/tests/sparktemplates/SparkTemplateDeployerTestCase.java
+++ b/modules/integration/tests-integration/src/test/java/org/wso2/das/integration/tests/sparktemplates/SparkTemplateDeployerTestCase.java
@@ -58,7 +58,7 @@ public class SparkTemplateDeployerTestCase extends DASIntegrationTest {
         File newFile = new File(getClass().getResource(File.separator + "sparktemplates" + File.separator
                 + "TestDomain.xml").toURI());
         FileUtils.copyFileToDirectory(newFile, new File(ServerConfigurationManager.getCarbonHome() + File.separator
-                + "repository" + File.separator + "conf" + File.separator + "execution-manager" + File.separator
+                + "repository" + File.separator + "conf" + File.separator + "template-manager" + File.separator
                 + "domain-template" + File.separator));
         serverManager.restartForcefully();
 


### PR DESCRIPTION
This is due to renaming the folder structure of execution manger to template manager. Please review and merge.