### PR TITLE
Migrate few dependencies to the latest versions

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -285,7 +285,7 @@
     </build>
 
     <properties>
-        <identity.jar.version>5.2.0</identity.jar.version>
+        <identity.jar.version>5.11.118</identity.jar.version>
         <cep.samples.distribution.version>4.2.1-SNAPSHOT</cep.samples.distribution.version>
     </properties>
 

--- a/modules/p2-profile-gen/pom.xml
+++ b/modules/p2-profile-gen/pom.xml
@@ -160,12 +160,12 @@
 
                                 <!-- ************** START - User Management ********* -->
                                 <featureArtifactDef>
-                                    org.wso2.carbon.identity:org.wso2.carbon.user.mgt.feature:${carbon.identity.version}
+                                        org.wso2.carbon.identity.framework:org.wso2.carbon.user.mgt.feature:${carbon.identity.version}
                                 </featureArtifactDef><featureArtifactDef>
-                                    org.wso2.carbon.identity:org.wso2.carbon.identity.core.ui.feature:${carbon.identity.version}
+                                    org.wso2.carbon.identity.framework:org.wso2.carbon.identity.core.ui.feature:${carbon.identity.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.identity:org.wso2.carbon.identity.core.server.feature:${carbon.identity.version}
+                                    org.wso2.carbon.identity.framework:org.wso2.carbon.identity.core.server.feature:${carbon.identity.version}
                                 </featureArtifactDef>
                                 <!-- ************** END - User Management ********* -->
 
@@ -260,7 +260,7 @@
                                     org.wso2.carbon.identity:org.wso2.carbon.identity.authenticator.saml2.sso.ui.feature:${carbon.identity.saml2.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.identity:org.wso2.carbon.security.mgt.feature:${carbon.identity.version}
+                                    org.wso2.carbon.identity.framework:org.wso2.carbon.security.mgt.feature:${carbon.identity.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.das:org.wso2.das.multitenancy.dashboard.ui.feature:${das.release.version}

--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@
     <properties>
         <das.release.version>3.2.0-beta-SNAPSHOT</das.release.version>
 
-        <carbon.kernel.version>4.4.21</carbon.kernel.version>
+        <carbon.kernel.version>4.4.24</carbon.kernel.version>
 
         <!-- Data TG repo -->
         <carbon.analytics.version>1.3.14</carbon.analytics.version>
@@ -455,17 +455,17 @@
 
         <carbon.automationutils.version>4.4.1</carbon.automationutils.version>
         <carbon.automation.version>4.4.2</carbon.automation.version>
-        <carbon.registry.version>4.6.25</carbon.registry.version>
-        <carbon.multitenancy.version>4.6.0</carbon.multitenancy.version>
-        <carbon.deployment.version>4.7.0</carbon.deployment.version>
-        <carbon.identity.version>5.2.0</carbon.identity.version>
+        <carbon.registry.version>4.6.27</carbon.registry.version>
+        <carbon.multitenancy.version>4.6.8</carbon.multitenancy.version>
+        <carbon.deployment.version>4.7.14</carbon.deployment.version>
+        <carbon.identity.version>5.11.118</carbon.identity.version>
         <carbon.identity.saml2.version>5.1.3</carbon.identity.saml2.version>
-        <carbon.commons.version>4.5.4</carbon.commons.version>
+        <carbon.commons.version>4.5.12</carbon.commons.version>
         <carbon.data.version>4.4.37</carbon.data.version>
         <carbon.metrics.version>1.2.3</carbon.metrics.version>
 
         <!-- Dashboards and Jaggery -->
-        <carbon.dashboard.version>2.0.2</carbon.dashboard.version>
+        <carbon.dashboard.version>2.0.16</carbon.dashboard.version>
         <jaggery.version>0.12.8</jaggery.version>
         <jaggery.modules.carbon.version>1.5.5</jaggery.modules.carbon.version>
         <jaggery.modules.process.version>1.5.5</jaggery.modules.process.version>


### PR DESCRIPTION
## Purpose
Migrating following components to the latest versions.

- carbon-kernel v4.4.24
- carbon-commons v4.5.12
- carbon-multitenancy v4.6.8
- carbon-deployment v4.7.14
- carbon-dashboards v2.0.16
- carbon-identity-framework v5.11.118
- carbon-registry v4.6.27

