### PR TITLE
Bump forget-me tool version

### DIFF
--- a/modules/distribution/src/scripts/forget-me.sh
+++ b/modules/distribution/src/scripts/forget-me.sh
@@ -34,4 +34,4 @@ PRGDIR=`dirname "$PRG"`
 [ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
 
 cd $CARBON_HOME
-sh $CARBON_HOME/repository/components/tools/identity-anonymization-tool/bin/forget-me -d $CARBON_HOME/repository/components/tools/identity-anonymization-tool/conf $@
+sh $CARBON_HOME/repository/components/tools/identity-anonymization-tool/bin/forget-me -d $CARBON_HOME/repository/components/tools/identity-anonymization-tool/conf -carbon $CARBON_HOME $@

--- a/pom.xml
+++ b/pom.xml
@@ -502,7 +502,7 @@
 
         <vizgrammar.version>2.0.0</vizgrammar.version>
 
-        <forgetme.tool.version>1.1.3</forgetme.tool.version>
+        <forgetme.tool.version>1.1.8</forgetme.tool.version>
 
         <project.scm.id>my-scm-server</project.scm.id>
     </properties>


### PR DESCRIPTION
## Purpose
This PR bumps the version of the forget-me tool to 1.1.8.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes