### PR TITLE
Fix sample CApps not being copied to the final distribution in Jenkins release builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ target
 *.ipr
 .idea
 .DS_Store
+
+# Ignore built sample CApps
+modules/samples/capps/target-capps/

--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -75,7 +75,7 @@
             </excludes>
         </fileSet>
         <fileSet>
-            <directory>../samples/capps/target</directory>
+            <directory>../samples/capps/target-capps</directory>
             <outputDirectory>${pom.artifactId}-${pom.version}/capps</outputDirectory>
         </fileSet>
 

--- a/modules/samples/capps/build.xml
+++ b/modules/samples/capps/build.xml
@@ -2,7 +2,7 @@
 <project name="create-sample-capps" default="zip" basedir=".">
 
     <property name="project-name" value="${ant.project.name}"/>
-    <property name="target-dir" value="target"/>
+    <property name="target-dir" value="target-capps"/>
 
     <property name="Smart_Home_dir" value="Smart_Home"/>
     <property name="Wikipedia_dir" value="Wikipedia"/>


### PR DESCRIPTION
## Purpose
Jenkins build process deletes `target` directory of a Maven module right after finishing `install` phase. This causes to lose built artifacts of sample CApps (.car files) in the `modules/samples/capps` module. Then when the distribution is created, sample CApps do not get copied as they have been deleted.

## Goals
Retain built sample CApps even after `modules/samples/capps` module is built.

## Approach
- When `modules/samples/capps` module gets build, copy built CApps (.car files) to `target-capps` directory instead of `target` directory.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
